### PR TITLE
fix AutoDisconnectHandler from triggering on tab changes

### DIFF
--- a/Plugin.SegmentedControl.Maui/Utils/PageHelper.cs
+++ b/Plugin.SegmentedControl.Maui/Utils/PageHelper.cs
@@ -53,9 +53,12 @@ namespace Plugin.SegmentedControl.Maui.Utils
 
                 case TabbedPage tabbedPage:
                     yield return tabbedPage;
-                    foreach (var p in GetNavigationTree(tabbedPage.CurrentPage))
+                    foreach (var tab in tabbedPage.Children)
                     {
-                        yield return p;
+                        foreach (var p in GetNavigationTree(tab))
+                        {
+                            yield return p;
+                        }
                     }
 
                     break;


### PR DESCRIPTION
This fixes an issue where the SegmentedControl stops working when switching from a tab with a SegmentedControl and later navigating to the tab again.

The AutoDisconnectHandler was triggering when leaving a tab, because only the tabbedPages current element was returned by the GetNavigationTree method. This is problematic as of the time of evaluation the tabbedPage.CurrentElement is already set to the new tab that is navigated to.

GetNavigationTree now returns all contained tabs, to not prematurely disconnect the handlers.